### PR TITLE
refactor: Replace handwritten `Ord` and `PartialOrd`

### DIFF
--- a/src/date_time.rs
+++ b/src/date_time.rs
@@ -30,7 +30,7 @@ use crate::error::{DateTimeRangeError, DateTimeRangeErrorKind};
 /// [MS-DOS date and time]: https://learn.microsoft.com/en-us/windows/win32/sysinfo/ms-dos-date-and-time
 /// [FAT]: https://en.wikipedia.org/wiki/File_Allocation_Table
 /// [ZIP]: https://en.wikipedia.org/wiki/ZIP_(file_format)
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DateTime {
     date: u16,
     time: u16,

--- a/src/date_time/cmp.rs
+++ b/src/date_time/cmp.rs
@@ -4,44 +4,13 @@
 
 //! Utilities for comparing and ordering values.
 
-use core::cmp::Ordering;
-
-use super::DateTime;
-
-impl Ord for DateTime {
-    fn cmp(&self, other: &Self) -> Ordering {
-        if let ordering @ (Ordering::Less | Ordering::Greater) = self.year().cmp(&other.year()) {
-            return ordering;
-        }
-        if let ordering @ (Ordering::Less | Ordering::Greater) = self.month().cmp(&other.month()) {
-            return ordering;
-        }
-        if let ordering @ (Ordering::Less | Ordering::Greater) = self.day().cmp(&other.day()) {
-            return ordering;
-        }
-        if let ordering @ (Ordering::Less | Ordering::Greater) = self.hour().cmp(&other.hour()) {
-            return ordering;
-        }
-        if let ordering @ (Ordering::Less | Ordering::Greater) = self.minute().cmp(&other.minute())
-        {
-            return ordering;
-        }
-        self.second().cmp(&other.second())
-    }
-}
-
-impl PartialOrd for DateTime {
-    #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use core::cmp::Ordering;
+
     use time::macros::datetime;
 
-    use super::*;
+    use super::super::DateTime;
 
     #[test]
     fn equality() {


### PR DESCRIPTION
Use the derive macro to implement these.

## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/dos-date-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/dos-date-time/blob/develop/CODE_OF_CONDUCT.md
